### PR TITLE
Ensure deterministic listing of directory text files

### DIFF
--- a/GhostLink.py
+++ b/GhostLink.py
@@ -48,11 +48,12 @@ def ensure_dir(path: str) -> None:
 
 def list_text_files(dir_path: str) -> List[str]:
     try:
-        return [
+        # Sort for deterministic processing order
+        return sorted([
             os.path.join(dir_path, f)
             for f in os.listdir(dir_path)
             if os.path.isfile(os.path.join(dir_path, f)) and f.lower().endswith((".txt", ".md", ".log"))
-        ]
+        ])
     except Exception as e:
         logging.error(f"[x] Failed to list directory '{dir_path}': {e}")
         return []

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It defaults to **dense 8-FSK** with forward error correction, interleaving, and 
 ### Modes
 - `text` — Encode a short message passed on CLI
 - `file` — Encode a single UTF-8 text file
-- `dir` — Encode all files in a directory (non-recursive)
+- `dir` — Encode all files in a directory (non-recursive, processed in sorted order for determinism)
 
 ### Examples
 \t# 1) Quick start: CLI text -> out/

--- a/tests/test_list_text_files.py
+++ b/tests/test_list_text_files.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from GhostLink import list_text_files
+
+def test_list_text_files_returns_sorted_paths(tmp_path):
+    names = ["b.txt", "a.txt", "c.md", "d.log", "ignore.bin"]
+    for name in names:
+        (tmp_path / name).write_text("data")
+
+    result = list_text_files(str(tmp_path))
+    expected = sorted(str(tmp_path / n) for n in ["a.txt", "b.txt", "c.md", "d.log"])
+    assert result == list(expected)


### PR DESCRIPTION
## Summary
- Sort directory text file listing for deterministic processing
- Document deterministic ordering in README
- Add unit test for sorted list_text_files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b11d55608331834a0fb7b2dff1f1