### PR TITLE
Handle unreadable inputs

### DIFF
--- a/GhostLink.py
+++ b/GhostLink.py
@@ -445,15 +445,24 @@ def validate_args(args: argparse.Namespace) -> None:
 
 def iter_inputs(mode: str, input_arg: str) -> Iterable[Tuple[str, bytes]]:
     if mode == "text":
-        yield ("literal", read_utf8_bytes(input_arg, is_literal=True))
+        try:
+            yield ("literal", read_utf8_bytes(input_arg, is_literal=True))
+        except Exception as e:
+            logging.error(f"[x] Skipping literal input: {e}")
     elif mode == "file":
-        yield (os.path.basename(input_arg), read_utf8_bytes(input_arg, is_literal=False))
+        try:
+            yield (os.path.basename(input_arg), read_utf8_bytes(input_arg, is_literal=False))
+        except Exception as e:
+            logging.error(f"[x] Skipping '{input_arg}': {e}")
     else:  # dir
         files = list_text_files(input_arg)
         if not files:
             logging.warning("[!] No text files found to encode.")
         for fp in files:
-            yield (os.path.basename(fp), read_utf8_bytes(fp, is_literal=False))
+            try:
+                yield (os.path.basename(fp), read_utf8_bytes(fp, is_literal=False))
+            except Exception as e:
+                logging.error(f"[x] Skipping '{fp}': {e}")
 
 def main() -> int:
     args = parse_args()

--- a/tests/test_iter_inputs.py
+++ b/tests/test_iter_inputs.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import logging
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from GhostLink import iter_inputs, read_utf8_bytes
+
+
+def test_iter_inputs_skips_unreadable_files(tmp_path, monkeypatch, caplog):
+    good = tmp_path / "good.txt"
+    good.write_text("ok")
+    bad = tmp_path / "bad.txt"
+    bad.write_text("bad")
+
+    def fake_read(src, is_literal):
+        if src == str(bad):
+            raise OSError("boom")
+        return read_utf8_bytes(src, is_literal)
+
+    monkeypatch.setattr("GhostLink.read_utf8_bytes", fake_read)
+
+    with caplog.at_level(logging.ERROR):
+        result = list(iter_inputs("dir", str(tmp_path)))
+
+    assert [(name, data) for name, data in result] == [("good.txt", b"ok")]
+    assert "Skipping" in caplog.text
+
+
+def test_iter_inputs_processes_malformed_utf8(tmp_path, caplog):
+    bad = tmp_path / "bad.txt"
+    bad.write_bytes(b"\xff\xfe")
+
+    with caplog.at_level(logging.WARNING):
+        result = list(iter_inputs("dir", str(tmp_path)))
+
+    assert result == [("bad.txt", b"\xff\xfe")]
+    assert "not valid UTF-8" in caplog.text
+


### PR DESCRIPTION
## Summary
- Skip files that can't be read by catching exceptions in `iter_inputs`.
- Add regression tests covering unreadable and malformed text files.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b23ae3b88331ab43e86bdc5fb438