### PR TITLE
Preserve audio phase continuity across segments

### DIFF
--- a/tests/test_phase_continuity.py
+++ b/tests/test_phase_continuity.py
@@ -1,0 +1,23 @@
+import struct
+
+from GhostLink import symbols_to_audio
+
+
+def test_boundary_samples_continuous():
+    freqs = [1234.0]
+    sr = 8000
+    baud = 100.0
+    amp = 0.5
+    symbols = [0] * 5
+
+    combined, _ = symbols_to_audio(symbols * 2, freqs, sr, baud, amp,
+                                   phase0=0.0, gap_ms=0.0, ramp_ms=0.0)
+    part1, phase = symbols_to_audio(symbols, freqs, sr, baud, amp,
+                                    phase0=0.0, gap_ms=0.0, ramp_ms=0.0)
+    part2, _ = symbols_to_audio(symbols, freqs, sr, baud, amp,
+                                phase0=phase, gap_ms=0.0, ramp_ms=0.0)
+    joined = part1 + part2
+
+    assert joined == combined
+    samples1 = struct.unpack('<' + 'h' * (len(part1) // 2), part1)
+    assert samples1[-1] != 0


### PR DESCRIPTION
## Summary
- Track and propagate oscillator phase through the preamble and symbol synthesis to avoid discontinuities.
- Pass the preamble's final phase into symbol generation during encoding.
- Add regression test confirming seamless sample boundaries.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b460e5e48331b3caba4703d59eb9