### PR TITLE
Avoid mutating input bits in bits_to_symbols

### DIFF
--- a/GhostLink.py
+++ b/GhostLink.py
@@ -134,14 +134,15 @@ def bits_to_symbols(bits: List[int], order: int) -> List[int]:
     if order not in (4, 8):
         raise ValueError("order must be 4 or 8")
     k = 2 if order == 4 else 3
-    pad = (-len(bits)) % k
+    bits_copy = bits[:]
+    pad = (-len(bits_copy)) % k
     if pad:
-        bits += [0] * pad
+        bits_copy += [0] * pad
     symbols = []
-    for i in range(0, len(bits), k):
+    for i in range(0, len(bits_copy), k):
         val = 0
         for j in range(k):
-            val = (val << 1) | bits[i + j]
+            val = (val << 1) | bits_copy[i + j]
         symbols.append(val)  # 0..3 or 0..7
     return symbols
 

--- a/tests/test_bits_to_symbols.py
+++ b/tests/test_bits_to_symbols.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from GhostLink import bits_to_symbols
+
+
+def test_bits_to_symbols_preserves_input_list():
+    bits = [1, 0, 1, 1]
+    original = bits[:]
+    symbols = bits_to_symbols(bits, 8)
+    assert bits == original
+    assert symbols == [5, 4]


### PR DESCRIPTION
## Summary
- ensure bits_to_symbols uses a copy of input bits and returns symbols without mutating the original list
- add unit test verifying bits_to_symbols preserves the input list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b5d372988331bc18018b96cf176a