### PR TITLE
Add encoding pipeline tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pip install pytest
+      - run: pytest

--- a/tests/test_bits_to_symbols.py
+++ b/tests/test_bits_to_symbols.py
@@ -11,3 +11,8 @@ def test_bits_to_symbols_preserves_input_list():
     symbols = bits_to_symbols(bits, 8)
     assert bits == original
     assert symbols == [5, 4]
+
+def test_bits_to_symbols_order4_with_padding():
+    bits = [1, 0, 1, 1, 1]  # 5 bits -> padded to 6
+    symbols = bits_to_symbols(bits, 4)
+    assert symbols == [2, 3, 2]

--- a/tests/test_full_cycle.py
+++ b/tests/test_full_cycle.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from GhostLink import encode_bytes_to_wav
+from decoder import decode_wav
+
+
+def test_full_encode_decode_cycle(tmp_path):
+    message = b"hi"
+    out_dir = tmp_path
+    path, skipped = encode_bytes_to_wav(
+        user_bytes=message,
+        out_dir=str(out_dir),
+        base_name_hint="msg",
+        samplerate=16000,
+        baud=200.0,
+        amp=0.1,
+        dense=True,
+        mix_profile="streaming",
+        gap_ms=0.0,
+        preamble_s=0.5,
+        interleave_depth=2,
+        repeats=1,
+        ramp_ms=5.0,
+    )
+    assert skipped is False
+    decoded = decode_wav(
+        path=path,
+        baud=200.0,
+        dense=True,
+        mix_profile="streaming",
+        preamble_s=0.5,
+        interleave_depth=2,
+        repeats=1,
+    )
+    assert decoded == message

--- a/tests/test_hamming.py
+++ b/tests/test_hamming.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from GhostLink import hamming74_encode_nibble, hamming74_encode_bytes
+
+
+def test_hamming74_encode_nibble():
+    # nibble 0xA -> d3d2d1d0 = 1010
+    # parity bits: p1=1, p2=0, p3=1
+    assert hamming74_encode_nibble(0xA) == [1, 0, 1, 1, 0, 1, 0]
+
+
+def test_hamming74_encode_bytes():
+    # byte 0xA5 -> nibbles 0xA and 0x5
+    expected = [1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1]
+    assert hamming74_encode_bytes(bytes([0xA5])) == expected

--- a/tests/test_interleave.py
+++ b/tests/test_interleave.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from GhostLink import interleave
+from decoder import deinterleave
+
+
+def test_interleave_roundtrip():
+    bits = [0, 1, 1, 0, 1, 0, 0, 1, 1, 1]
+    depth = 4
+    inter = interleave(bits, depth)
+    assert inter != bits  # ensure interleaving actually rearranges
+    de = deinterleave(inter, depth)[:len(bits)]
+    assert de == bits


### PR DESCRIPTION
## Summary
- Add tests for Hamming(7,4) encoding helpers
- Verify interleaving round-trip with deinterleave
- Cover 4-FSK symbol mapping and full encode/decode cycle
- Run tests in GitHub Actions CI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b862699483319e2b6fc70fa4513f