### PR TITLE
refactor: centralize frequency profile

### DIFF
--- a/GhostLink.py
+++ b/GhostLink.py
@@ -27,6 +27,7 @@ import sys
 import time
 import wave
 from typing import List, Tuple, Iterable
+from profiles import freq_profile
 
 # ------------------------
 # Logging
@@ -237,24 +238,6 @@ def preamble(freqs: List[float], sr: int, amp: float, seconds: float) -> Tuple[b
 # ------------------------
 # Frequency profiles (codec-safe by design)
 # ------------------------
-def freq_profile(dense: bool, profile: str) -> List[float]:
-    """
-    Profiles chosen to survive typical consumer gear + lossy codecs.
-    streaming: conservative 1.5k–5k band (very codec-safe)
-    studio:    1.8k–6k (still safe; a little brighter)
-    """
-    if profile not in ("streaming", "studio"):
-        raise ValueError("mix-profile must be 'streaming' or 'studio'")
-
-    if dense:
-        # 8-FSK, equal-ish spacing; steer clear of sub-1k mud and >6k rolloff
-        return [1500.0, 1900.0, 2300.0, 2700.0, 3100.0, 3500.0, 3900.0, 4300.0] if profile == "streaming" \
-             else [1800.0, 2200.0, 2600.0, 3000.0, 3400.0, 3800.0, 4200.0, 4600.0]
-    else:
-        # 4-FSK
-        return [1600.0, 2100.0, 2700.0, 3300.0] if profile == "streaming" \
-             else [1800.0, 2200.0, 2600.0, 3000.0]
-
 # ------------------------
 # SQLite logging & dedupe
 # ------------------------

--- a/decoder.py
+++ b/decoder.py
@@ -12,6 +12,7 @@ import wave
 import sys
 import os
 from typing import List
+from profiles import freq_profile
 
 # ------------------------
 # Logging
@@ -23,19 +24,6 @@ def setup_logging(verbose: bool) -> None:
         format="%(asctime)s %(levelname)s %(message)s",
         datefmt="%H:%M:%S",
     )
-
-# ------------------------
-# Frequency profiles
-# ------------------------
-def freq_profile(dense: bool, profile: str) -> List[float]:
-    if profile not in ("streaming", "studio"):
-        raise ValueError("mix-profile must be 'streaming' or 'studio'")
-    if dense:
-        return [1500.0, 1900.0, 2300.0, 2700.0, 3100.0, 3500.0, 3900.0, 4300.0] if profile == "streaming" \
-            else [1800.0, 2200.0, 2600.0, 3000.0, 3400.0, 3800.0, 4200.0, 4600.0]
-    else:
-        return [1600.0, 2100.0, 2700.0, 3300.0] if profile == "streaming" \
-            else [1800.0, 2200.0, 2600.0, 3000.0]
 
 # ------------------------
 # Goertzel detector

--- a/profiles.py
+++ b/profiles.py
@@ -1,0 +1,19 @@
+"""Shared frequency profiles for GhostLink encoder/decoder."""
+
+from typing import List
+
+
+def freq_profile(dense: bool, profile: str) -> List[float]:
+    """Return carrier frequencies for the given profile.
+
+    Profiles are chosen to survive typical consumer gear and lossy codecs.
+    """
+    if profile not in ("streaming", "studio"):
+        raise ValueError("mix-profile must be 'streaming' or 'studio'")
+    if dense:
+        # 8-FSK, equal-ish spacing; steer clear of sub-1k mud and >6k rolloff
+        return [1500.0, 1900.0, 2300.0, 2700.0, 3100.0, 3500.0, 3900.0, 4300.0] if profile == "streaming" \
+            else [1800.0, 2200.0, 2600.0, 3000.0, 3400.0, 3800.0, 4200.0, 4600.0]
+    # 4-FSK
+    return [1600.0, 2100.0, 2700.0, 3300.0] if profile == "streaming" \
+        else [1800.0, 2200.0, 2600.0, 3000.0]

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from profiles import freq_profile
+import GhostLink
+import decoder
+
+
+def test_shared_freq_profile_reference():
+    assert GhostLink.freq_profile is freq_profile
+    assert decoder.freq_profile is freq_profile
+    assert freq_profile(True, "streaming")[0] == 1500.0
+    assert freq_profile(False, "studio")[3] == 3000.0


### PR DESCRIPTION
## Summary
- extract `freq_profile` to new `profiles` module for reuse
- import shared frequency helper in `GhostLink` and `decoder`
- cover shared profile function with a dedicated test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896bc19d2188331a2147a6cc0a298ec