### PR TITLE
Remove deprecated amp flag from decoder

### DIFF
--- a/decoder.py
+++ b/decoder.py
@@ -182,7 +182,6 @@ def parse_args() -> argparse.Namespace:
     )
     p.add_argument("wav", help="Input WAV file")
     p.add_argument("--baud", type=float, default=90.0, help="Symbol rate")
-    p.add_argument("--amp", type=float, default=0.06, help=argparse.SUPPRESS)  # compatibility placeholder
     p.add_argument("--preamble", type=float, default=0.8, help="Preamble seconds to skip")
     p.add_argument("--dense", action="store_true", help="Expect dense 8-FSK (default)")
     p.add_argument("--sparse", action="store_true", help="Expect sparse 4-FSK")

--- a/tests/test_decoder_args.py
+++ b/tests/test_decoder_args.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import decoder
+
+
+def test_parse_args_rejects_unknown_flag(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["decoder.py", "in.wav", "--amp"])
+    with pytest.raises(SystemExit) as e:
+        decoder.parse_args()
+    assert e.value.code != 0


### PR DESCRIPTION
## Summary
- remove leftover `--amp` flag from `decoder.py` CLI parser
- add regression test ensuring decoder rejects unknown options

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896c02f641483318d463998e281bb20