### PR TITLE
docs: update usage to installed scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,19 @@ GhostLink hides structured text inside audio as carefully band-placed FSK tones 
 - macOS, Linux, or Windows
 
 ### Clone & Prepare
-```
-  git clone https://github.com/13alvone/GhostLink.git
-  cd GhostLink
-  python3 -m venv .venv
-  source .venv/bin/activate     # Windows: .venv\Scripts\activate
-  pip install -r requirements.txt
-  chmod +x ghostlink.py
+```bash
+git clone https://github.com/13alvone/GhostLink.git
+cd GhostLink
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install .
 ```
 ---
 
 ## Usage
 
 ### General Form
-```./ghostlink.py <mode> <input> <outdir> [options]```
+```ghostlink <mode> <input> <outdir> [options]```
 
 ### Modes
 - `text` — Encode a short message passed on CLI
@@ -43,24 +42,24 @@ GhostLink hides structured text inside audio as carefully band-placed FSK tones 
 ### Examples
 ```
 # 1) Quick start: CLI text -> out/
-./ghostlink.py text "trust_no_one" out/
+ghostlink text "trust_no_one" out/
 
 # 2) Single file, dense defaults, streaming-safe band
-./ghostlink.py file ./secret.txt out/
+ghostlink file ./secret.txt out/
 
 # 3) Directory batch; sparse 4-FSK; slightly slower baud
-./ghostlink.py dir ./payloads out/ --sparse --baud 60
+ghostlink dir ./payloads out/ --sparse --baud 60
 
 # 4) Louder lab test run (don’t do this in a real mix)
-./ghostlink.py text "HELLO" out/ --amp 0.2 -v
+ghostlink text "HELLO" out/ --amp 0.2 -v
 
 # 5) Studio profile (a bit brighter), higher baud
-./ghostlink.py text "msg" out/ --mix-profile studio --baud 120
+ghostlink text "msg" out/ --mix-profile studio --baud 120
 ```
 
 ### Decoding
 # Recover text from a GhostLink WAV
-```./decoder.py out/msg_ce67eacbbb93.wav```
+```ghostlink-decode out/msg_ce67eacbbb93.wav```
 
 ---
 
@@ -118,12 +117,12 @@ Filenames include the first 12 hex chars of the framed payload hash (sha256) for
 
 ## CLI Reference
 ```
-  ./ghostlink.py <mode> <input> <outdir>
+  ghostlink <mode> <input> <outdir>
       [--samplerate 48000] [--baud 90] [--amp 0.06]
       [--dense|--sparse] [--mix-profile streaming|studio]
       [--preamble 0.8] [--gap 0] [--interleave 4] [--repeats 2] [--ramp 5]
       [-v|--verbose]
-  ./decoder.py <wavfile>
+  ghostlink-decode <wavfile>
       [--baud 90] [--dense|--sparse] [--mix-profile streaming|studio]
       [--preamble 0.8] [--interleave 4] [--repeats 2] [-v|--verbose]
 ```

--- a/ghostlink/__main__.py
+++ b/ghostlink/__main__.py
@@ -9,10 +9,10 @@ Modes:
   - dir:  encode all UTF-8 text files in a directory (non-recursive)
 
 Examples:
-  ./ghostlink.py text "trust_no_one" out/
-  ./ghostlink.py file ./secret.txt out/ --dense
-  ./ghostlink.py dir ./payloads/ out/ --sparse --baud 60
-  ./ghostlink.py text "msg" out/ --mix-profile streaming --amp 0.04 --verbose
+  ghostlink text "trust_no_one" out/
+  ghostlink file ./secret.txt out/ --dense
+  ghostlink dir ./payloads/ out/ --sparse --baud 60
+  ghostlink text "msg" out/ --mix-profile streaming --amp 0.04 --verbose
 """
 
 import argparse

--- a/ghostlink/decoder.py
+++ b/ghostlink/decoder.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-GhostLink Decoder: Recover text from FSK audio produced by ghostlink.py.
+GhostLink Decoder: Recover text from FSK audio produced by the `ghostlink` CLI.
 """
 
 import argparse

--- a/tests/test_decoder_args.py
+++ b/tests/test_decoder_args.py
@@ -5,7 +5,7 @@ from ghostlink import decoder
 
 
 def test_parse_args_rejects_unknown_flag(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["decoder.py", "in.wav", "--amp"])
+    monkeypatch.setattr(sys, "argv", ["ghostlink-decode", "in.wav", "--amp"])
     with pytest.raises(SystemExit) as e:
         decoder.parse_args()
     assert e.value.code != 0


### PR DESCRIPTION
## Summary
- use `pip install .` and venv in clone instructions
- show `ghostlink` and `ghostlink-decode` in examples and CLI reference
- drop references to script paths in docstrings and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896cb2fd17c83318c5919651801ba8e