### PR TITLE
docs: add project layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ GhostLink hides structured text inside audio as carefully band-placed FSK tones 
 - **No external dependencies:** pure Python 3 standard library.
 - **Three input modes:** CLI text, single file, or directory of text files.
 
+## Project Layout
+
+- `ghostlink/` – core package (`__main__.py`, `decoder.py`, `profiles.py`)
+- `tests/` – unit tests validating encoding/decoding
+- `pyproject.toml` – packaging and script entry points
+- `requirements.txt` – placeholder for future dependencies
+
+```
+GhostLink/
+├── ghostlink/
+├── tests/
+├── pyproject.toml
+└── requirements.txt
+```
+
 ---
 
 ## Install


### PR DESCRIPTION
## Summary
- document repo structure with new 'Project Layout' section

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896cc09f51083319a44a66f507c7090