### PR TITLE
Clarify CLI and decoder usage examples

### DIFF
--- a/ghostlink/__main__.py
+++ b/ghostlink/__main__.py
@@ -10,7 +10,7 @@ Modes:
 
 Examples:
   ghostlink text "trust_no_one" out/
-  ghostlink file ./secret.txt out/ --dense
+  python -m ghostlink file ./secret.txt out/ --dense
   ghostlink dir ./payloads/ out/ --sparse --baud 60
   ghostlink text "msg" out/ --mix-profile streaming --amp 0.04 --verbose
 """

--- a/ghostlink/decoder.py
+++ b/ghostlink/decoder.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """
-GhostLink Decoder: Recover text from FSK audio produced by the `ghostlink` CLI.
+GhostLink Decoder: Recover text from FSK audio produced by the `ghostlink` encoder.
+
+Examples:
+  ghostlink-decode ./message.wav
+  python -m ghostlink.decoder ./message.wav
 """
 
 import argparse


### PR DESCRIPTION
## Summary
- mention python module usage in encoder help examples
- clarify decoder description and show new invocation examples

## Testing
- `python -m ghostlink text "hello" outdir`
- `python -m ghostlink.decoder outdir/msg_d5207d7f47b6.wav`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896ccabe8c88331879279b8212dc1c8