### PR TITLE
Use Gibberlink frame signature

### DIFF
--- a/ghostlink/__main__.py
+++ b/ghostlink/__main__.py
@@ -219,7 +219,7 @@ def write_wav(path: str, sr: int, pcm: bytes) -> None:
 # Framing / payload
 # ------------------------
 def build_payload(user_bytes: bytes) -> bytes:
-    magic = b"GL1"
+    magic = b"GIB"
     length = struct.pack(">I", len(user_bytes))
     crc = struct.pack(">I", binascii.crc32(user_bytes) & 0xFFFFFFFF)
     return magic + length + user_bytes + crc

--- a/ghostlink/decoder.py
+++ b/ghostlink/decoder.py
@@ -143,7 +143,7 @@ def decode_symbols(symbols: List[int], order: int, interleave_depth: int) -> byt
 def parse_payload(data: bytes) -> bytes:
     if len(data) < 3 + 4 + 4:
         raise ValueError("payload too short")
-    if data[:3] != b"GL1":
+    if data[:3] != b"GIB":
         raise ValueError("bad magic")
     length = struct.unpack(">I", data[3:7])[0]
     need = 3 + 4 + length + 4

--- a/tests/test_parse_payload.py
+++ b/tests/test_parse_payload.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 def test_parse_payload_bad_magic():
     payload = build_payload(b"hi")
-    bad = b"BAD" + payload[3:]
+    bad = b"BAD" + payload[len(b"GIB"):]
     with pytest.raises(ValueError, match="bad magic"):
         parse_payload(bad)
 


### PR DESCRIPTION
## Summary
- switch payload framing magic to Gibberlink signature
- decode using new signature for consistent parsing
- update test for changed magic bytes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896da39ff0c83318f20d82e52f7a3e6