### PR TITLE
Rename history DB to gibberlink and migrate legacy files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GhostLink hides structured text inside audio as carefully band-placed FSK tones 
 - **Codec-safe by design:** carriers live in 1.5–5 kHz (“streaming” profile, default) or 1.8–6 kHz (“studio”).
 - **Dense by default:** 8-FSK + Hamming(7,4) + interleaving + optional repeats.
 - **Hash-based dedupe:** payload frame SHA-256 is the unique key; if a prior identical encode exists on disk, the run is skipped.
-- **SQLite history:** every encode (or skip) is tracked in `ghostlink_history.db` in the output directory.
+- **SQLite history:** every encode (or skip) is tracked in `gibberlink_history.db` in the output directory (legacy `ghostlink_history.db` files are migrated automatically).
 - **No external dependencies:** pure Python 3 standard library.
 - **Three input modes:** CLI text, single file, or directory of text files.
 
@@ -102,7 +102,7 @@ ghostlink text "msg" out/ --mix-profile studio --baud 120
 ## Output
 Each encode produces:
 - `out/<base>_<sha12>.wav` — The audio payload
-- `out/ghostlink_history.db` — SQLite history of encodes
+- `out/gibberlink_history.db` — SQLite history of encodes
 
 Filenames include the first 12 hex chars of the framed payload hash (sha256) for traceability.
 

--- a/ghostlink/__main__.py
+++ b/ghostlink/__main__.py
@@ -320,8 +320,18 @@ def encode_bytes_to_wav(user_bytes: bytes, out_dir: str, base_name_hint: str,
     framed_hash = sha256_hex(payload)
     crc_hex = f"{binascii.crc32(user_bytes) & 0xFFFFFFFF:08x}"
 
-    db_path = os.path.join(out_dir, "ghostlink_history.db")
+    db_path = os.path.join(out_dir, "gibberlink_history.db")
     ensure_dir(out_dir)
+
+    legacy_path = os.path.join(out_dir, "ghostlink_history.db")
+    if not os.path.exists(db_path) and os.path.exists(legacy_path):
+        try:
+            os.rename(legacy_path, db_path)
+            logging.info(f"[i] Migrated legacy DB: {legacy_path} -> {db_path}")
+        except Exception as e:
+            logging.warning(f"[!] Failed to migrate legacy DB: {e}")
+            db_path = legacy_path
+
     db_init(db_path)
 
     exists, prior_path = db_has_hash(db_path, framed_hash)

--- a/tests/test_db_migration.py
+++ b/tests/test_db_migration.py
@@ -1,0 +1,32 @@
+from ghostlink import encode_bytes_to_wav
+from ghostlink.__main__ import db_init
+import sqlite3
+
+
+def test_legacy_db_migrates(tmp_path):
+    legacy = tmp_path / "ghostlink_history.db"
+    db_init(str(legacy))
+    encode_bytes_to_wav(
+        user_bytes=b"hi",
+        out_dir=str(tmp_path),
+        base_name_hint="msg",
+        samplerate=16000,
+        baud=200.0,
+        amp=0.1,
+        dense=True,
+        mix_profile="streaming",
+        gap_ms=0.0,
+        preamble_s=0.5,
+        interleave_depth=2,
+        repeats=1,
+        ramp_ms=5.0,
+    )
+    new_db = tmp_path / "gibberlink_history.db"
+    assert new_db.exists()
+    assert not legacy.exists()
+    conn = sqlite3.connect(new_db)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM encodes").fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 1

--- a/tests/test_full_cycle.py
+++ b/tests/test_full_cycle.py
@@ -21,6 +21,7 @@ def test_full_encode_decode_cycle(tmp_path):
         ramp_ms=5.0,
     )
     assert skipped is False
+    assert (out_dir / "gibberlink_history.db").exists()
     decoded = decode_wav(
         path=path,
         baud=200.0,


### PR DESCRIPTION
## Summary
- use `gibberlink_history.db` as the history database
- migrate any existing `ghostlink_history.db` to the new filename
- document new DB name and add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896dbc618ec8331a6299d54bf2aa3d5