### PR TITLE
Rename CLI references from GhostLink to Gibberlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# GhostLink — Stealth Text-to-Audio Encoder (Dense 8-FSK)
+# Gibberlink — Stealth Text-to-Audio Encoder (Dense 8-FSK)
 
 ## Overview
-GhostLink hides structured text inside audio as carefully band-placed FSK tones designed to survive consumer playback chains and lossy streaming codecs. It defaults to **dense 8-FSK** with forward error correction, interleaving, and repeats for robustness; a 4-FSK mode is available for extra margin.
+Gibberlink hides structured text inside audio as carefully band-placed FSK tones designed to survive consumer playback chains and lossy streaming codecs. It defaults to **dense 8-FSK** with forward error correction, interleaving, and repeats for robustness; a 4-FSK mode is available for extra margin.
 
 ### Key Properties
 - **Codec-safe by design:** carriers live in 1.5–5 kHz (“streaming” profile, default) or 1.8–6 kHz (“studio”).
@@ -19,7 +19,7 @@ GhostLink hides structured text inside audio as carefully band-placed FSK tones 
 - `requirements.txt` – placeholder for future dependencies
 
 ```
-GhostLink/
+Gibberlink/
 ├── ghostlink/
 ├── tests/
 ├── pyproject.toml
@@ -36,8 +36,8 @@ GhostLink/
 
 ### Clone & Prepare
 ```bash
-git clone https://github.com/13alvone/GhostLink.git
-cd GhostLink
+git clone https://github.com/13alvone/Gibberlink.git
+cd Gibberlink
 python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install .
@@ -47,7 +47,7 @@ pip install .
 ## Usage
 
 ### General Form
-```ghostlink <mode> <input> <outdir> [options]```
+```gibberlink <mode> <input> <outdir> [options]```
 
 ### Modes
 - `text` — Encode a short message passed on CLI
@@ -57,24 +57,24 @@ pip install .
 ### Examples
 ```
 # 1) Quick start: CLI text -> out/
-ghostlink text "trust_no_one" out/
+gibberlink text "trust_no_one" out/
 
 # 2) Single file, dense defaults, streaming-safe band
-ghostlink file ./secret.txt out/
+gibberlink file ./secret.txt out/
 
 # 3) Directory batch; sparse 4-FSK; slightly slower baud
-ghostlink dir ./payloads out/ --sparse --baud 60
+gibberlink dir ./payloads out/ --sparse --baud 60
 
 # 4) Louder lab test run (don’t do this in a real mix)
-ghostlink text "HELLO" out/ --amp 0.2 -v
+gibberlink text "HELLO" out/ --amp 0.2 -v
 
 # 5) Studio profile (a bit brighter), higher baud
-ghostlink text "msg" out/ --mix-profile studio --baud 120
+gibberlink text "msg" out/ --mix-profile studio --baud 120
 ```
 
 ### Decoding
-# Recover text from a GhostLink WAV
-```ghostlink-decode out/msg_ce67eacbbb93.wav```
+# Recover text from a Gibberlink WAV
+```gibberlink-decode out/msg_ce67eacbbb93.wav```
 
 ---
 
@@ -110,13 +110,13 @@ Filenames include the first 12 hex chars of the framed payload hash (sha256) for
 
 ## Dedupe Logic
 - The unique key is SHA-256 over the framed payload (`magic + length + data + CRC32`).
-- If the same payload was already written **and** the target WAV file still exists, GhostLink skips re-encoding.
+- If the same payload was already written **and** the target WAV file still exists, Gibberlink skips re-encoding.
 - Skips and writes are both recorded in SQLite (writes as rows; skips are implied by the UNIQUE constraint + presence check).
 
 ---
 
 ## Recommended Mix Practices
-- Render GhostLink track at low gain (`amp 0.03–0.06`) and tuck beneath steady, broadband content (pads, room tone, cymbal wash).
+- Render Gibberlink track at low gain (`amp 0.03–0.06`) and tuck beneath steady, broadband content (pads, room tone, cymbal wash).
 - Keep the carriers unobvious: avoid boosting 1.5–5 kHz with mastering EQ; a gentle shelf down can help.
 - Avoid ultrasonics (>16 kHz); streaming codecs often remove them entirely.
 - If worried about dropout under heavy compression, increase `--repeats` or `--interleave` rather than cranking `amp`.
@@ -132,12 +132,12 @@ Filenames include the first 12 hex chars of the framed payload hash (sha256) for
 
 ## CLI Reference
 ```
-  ghostlink <mode> <input> <outdir>
+  gibberlink <mode> <input> <outdir>
       [--samplerate 48000] [--baud 90] [--amp 0.06]
       [--dense|--sparse] [--mix-profile streaming|studio]
       [--preamble 0.8] [--gap 0] [--interleave 4] [--repeats 2] [--ramp 5]
       [-v|--verbose]
-  ghostlink-decode <wavfile>
+  gibberlink-decode <wavfile>
       [--baud 90] [--dense|--sparse] [--mix-profile streaming|studio]
       [--preamble 0.8] [--interleave 4] [--repeats 2] [-v|--verbose]
 ```
@@ -150,7 +150,7 @@ Filenames include the first 12 hex chars of the framed payload hash (sha256) for
 
 ## FAQ
 **Q:** Can I guarantee zero frequency loss on every platform?  
-**A:** No one can—playback chains vary wildly. GhostLink mitigates this by:
+**A:** No one can—playback chains vary wildly. Gibberlink mitigates this by:
 1. Confining carriers to a proven codec-survivable band.
 2. Spacing carriers to reduce intermod/aliasing issues.
 3. Using interleaving + repeats so partial losses don’t kill the message.

--- a/ghostlink/__init__.py
+++ b/ghostlink/__init__.py
@@ -1,7 +1,7 @@
-"""GhostLink package.
+"""Gibberlink package.
 
 This package exposes encoding and decoding helpers as well as the
-``main`` function used by the ``ghostlink`` console script.
+``main`` function used by the ``gibberlink`` console script.
 """
 
 from .__main__ import *  # noqa: F401,F403

--- a/ghostlink/__main__.py
+++ b/ghostlink/__main__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-GhostLink: Stealth audio encoder for embedding structured text in music.
+Gibberlink: Stealth audio encoder for embedding structured text in music.
 Dense-by-default 8-FSK with FEC, codec-safe frequency sets, and SQLite+hash dedupe.
 
 Modes:
@@ -9,10 +9,10 @@ Modes:
   - dir:  encode all UTF-8 text files in a directory (non-recursive)
 
 Examples:
-  ghostlink text "trust_no_one" out/
+  gibberlink text "trust_no_one" out/
   python -m ghostlink file ./secret.txt out/ --dense
-  ghostlink dir ./payloads/ out/ --sparse --baud 60
-  ghostlink text "msg" out/ --mix-profile streaming --amp 0.04 --verbose
+  gibberlink dir ./payloads/ out/ --sparse --baud 60
+  gibberlink text "msg" out/ --mix-profile streaming --amp 0.04 --verbose
 """
 
 import argparse
@@ -402,7 +402,7 @@ def encode_bytes_to_wav(user_bytes: bytes, out_dir: str, base_name_hint: str,
 # ------------------------
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
-        description="GhostLink: encode text into dense/sparse FSK audio for stealth embedding.",
+        description="Gibberlink: encode text into dense/sparse FSK audio for stealth embedding.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     # Positional: mode, input, outdir (per user preference)

--- a/ghostlink/decoder.py
+++ b/ghostlink/decoder.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-GhostLink Decoder: Recover text from FSK audio produced by the `ghostlink` encoder.
+Gibberlink Decoder: Recover text from FSK audio produced by the `gibberlink` encoder.
 
 Examples:
-  ghostlink-decode ./message.wav
+  gibberlink-decode ./message.wav
   python -m ghostlink.decoder ./message.wav
 """
 
@@ -181,7 +181,7 @@ def decode_wav(path: str, baud: float, dense: bool, mix_profile: str,
 # ------------------------
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
-        description="GhostLink decoder: recover text from FSK audio.",
+        description="Gibberlink decoder: recover text from FSK audio.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     p.add_argument("wav", help="Input WAV file")

--- a/ghostlink/profiles.py
+++ b/ghostlink/profiles.py
@@ -1,4 +1,4 @@
-"""Shared frequency profiles for GhostLink encoder/decoder."""
+"""Shared frequency profiles for Gibberlink encoder/decoder."""
 
 from typing import List
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,5 @@ requires-python = ">=3.8"
 dependencies = []
 
 [project.scripts]
-ghostlink = "ghostlink.__main__:main"
-ghostlink-decode = "ghostlink.decoder:main"
+gibberlink = "ghostlink.__main__:main"
+gibberlink-decode = "ghostlink.decoder:main"

--- a/tests/test_decoder_args.py
+++ b/tests/test_decoder_args.py
@@ -5,7 +5,7 @@ from ghostlink import decoder
 
 
 def test_parse_args_rejects_unknown_flag(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["ghostlink-decode", "in.wav", "--amp"])
+    monkeypatch.setattr(sys, "argv", ["gibberlink-decode", "in.wav", "--amp"])
     with pytest.raises(SystemExit) as e:
         decoder.parse_args()
     assert e.value.code != 0


### PR DESCRIPTION
## Summary
- Update module docstrings and CLI help strings to refer to Gibberlink
- Rename console scripts and documentation examples to `gibberlink` and `gibberlink-decode`
- Adjust tests for new command names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896dcdd0338833186a0cae89ff903c3