### PR TITLE
Align carrier frequency profiles with Gibberlink spec

### DIFF
--- a/gibberlink/profiles.py
+++ b/gibberlink/profiles.py
@@ -11,9 +11,35 @@ def freq_profile(dense: bool, profile: str) -> List[float]:
     if profile not in ("streaming", "studio"):
         raise ValueError("mix-profile must be 'streaming' or 'studio'")
     if dense:
-        # 8-FSK, equal-ish spacing; steer clear of sub-1k mud and >6k rolloff
-        return [1500.0, 1900.0, 2300.0, 2700.0, 3100.0, 3500.0, 3900.0, 4300.0] if profile == "streaming" \
-            else [1800.0, 2200.0, 2600.0, 3000.0, 3400.0, 3800.0, 4200.0, 4600.0]
-    # 4-FSK
-    return [1600.0, 2100.0, 2700.0, 3300.0] if profile == "streaming" \
-        else [1800.0, 2200.0, 2600.0, 3000.0]
+        # 8-FSK carriers from Gibberlink spec
+        return [
+            1500.0,
+            2000.0,
+            2500.0,
+            3000.0,
+            3500.0,
+            4000.0,
+            4500.0,
+            5000.0,
+        ] if profile == "streaming" else [
+            1800.0,
+            2400.0,
+            3000.0,
+            3600.0,
+            4200.0,
+            4800.0,
+            5400.0,
+            6000.0,
+        ]
+    # 4-FSK carriers from Gibberlink spec
+    return [
+        1750.0,
+        2750.0,
+        3750.0,
+        4750.0,
+    ] if profile == "streaming" else [
+        2100.0,
+        3300.0,
+        4500.0,
+        5700.0,
+    ]

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -6,5 +6,16 @@ from gibberlink import decoder
 def test_shared_freq_profile_reference():
     assert gibberlink.freq_profile is freq_profile
     assert decoder.freq_profile is freq_profile
-    assert freq_profile(True, "streaming")[0] == 1500.0
-    assert freq_profile(False, "studio")[3] == 3000.0
+    streaming_dense = freq_profile(True, "streaming")
+    assert streaming_dense == [
+        1500.0,
+        2000.0,
+        2500.0,
+        3000.0,
+        3500.0,
+        4000.0,
+        4500.0,
+        5000.0,
+    ]
+    studio_sparse = freq_profile(False, "studio")
+    assert studio_sparse == [2100.0, 3300.0, 4500.0, 5700.0]


### PR DESCRIPTION
## Summary
- update `freq_profile` with Gibberlink-defined carrier frequencies for dense 8-FSK and sparse 4-FSK modes
- expand profile tests to check full frequency tables for streaming and studio modes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e17f0c1083318d378a982a89a948