### PR TITLE
Refine tests for Gibberlink framing and CLI round-trips

### DIFF
--- a/tests/test_cli_round_trip.py
+++ b/tests/test_cli_round_trip.py
@@ -1,0 +1,24 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_round_trip(tmp_path):
+    msg = "hello"
+    # Encode message via CLI
+    subprocess.run(
+        [sys.executable, "-m", "gibberlink", "text", msg, str(tmp_path)],
+        check=True,
+        capture_output=True,
+    )
+    wav_files = list(Path(tmp_path).glob("*.wav"))
+    assert len(wav_files) == 1
+    wav_path = wav_files[0]
+    # Decode using reference decoder CLI
+    proc = subprocess.run(
+        [sys.executable, "-m", "gibberlink.decoder", str(wav_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.stdout.strip() == msg

--- a/tests/test_full_cycle.py
+++ b/tests/test_full_cycle.py
@@ -1,6 +1,8 @@
 from gibberlink import encode_bytes_to_wav
 from gibberlink.decoder import decode_wav
 
+HISTORY_DB_NAME = "gibberlink_history.db"
+
 
 def test_full_encode_decode_cycle(tmp_path):
     message = b"hi"
@@ -21,7 +23,7 @@ def test_full_encode_decode_cycle(tmp_path):
         ramp_ms=5.0,
     )
     assert skipped is False
-    assert (out_dir / "gibberlink_history.db").exists()
+    assert (out_dir / HISTORY_DB_NAME).exists()
     decoded = decode_wav(
         path=path,
         baud=200.0,

--- a/tests/test_parse_payload.py
+++ b/tests/test_parse_payload.py
@@ -6,10 +6,10 @@ from pathlib import Path
 
 
 def test_parse_payload_bad_magic():
-    payload = build_payload(b"hi")
-    bad = b"BAD" + payload[len(b"GIB"):]
+    payload = bytearray(build_payload(b"hi"))
+    payload[:3] = b"BAD"
     with pytest.raises(ValueError, match="bad magic"):
-        parse_payload(bad)
+        parse_payload(bytes(payload))
 
 
 def test_parse_payload_truncated():


### PR DESCRIPTION
## Summary
- Make payload magic checks independent of hard-coded bytes
- Centralize history DB name in full-cycle test
- Add CLI encode/decode round-trip test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896e2e4b1e88331b424696390564d02