### PR TITLE
refactor: centralize magic constant

### DIFF
--- a/gibberlink/__main__.py
+++ b/gibberlink/__main__.py
@@ -28,6 +28,7 @@ import time
 import wave
 from typing import List, Tuple, Iterable
 from .profiles import freq_profile
+from .constants import GIB_MAGIC
 
 # ------------------------
 # Logging
@@ -219,7 +220,7 @@ def write_wav(path: str, sr: int, pcm: bytes) -> None:
 # Framing / payload
 # ------------------------
 def build_payload(user_bytes: bytes) -> bytes:
-    magic = b"GIB"
+    magic = GIB_MAGIC
     length = struct.pack(">I", len(user_bytes))
     crc = struct.pack(">I", binascii.crc32(user_bytes) & 0xFFFFFFFF)
     return magic + length + user_bytes + crc

--- a/gibberlink/constants.py
+++ b/gibberlink/constants.py
@@ -1,0 +1,3 @@
+"""Shared constants for Gibberlink."""
+
+GIB_MAGIC = b"GIB"

--- a/gibberlink/decoder.py
+++ b/gibberlink/decoder.py
@@ -17,6 +17,7 @@ import sys
 import os
 from typing import List
 from .profiles import freq_profile
+from .constants import GIB_MAGIC
 
 # ------------------------
 # Logging
@@ -143,7 +144,7 @@ def decode_symbols(symbols: List[int], order: int, interleave_depth: int) -> byt
 def parse_payload(data: bytes) -> bytes:
     if len(data) < 3 + 4 + 4:
         raise ValueError("payload too short")
-    if data[:3] != b"GIB":
+    if data[:3] != GIB_MAGIC:
         raise ValueError("bad magic")
     length = struct.unpack(">I", data[3:7])[0]
     need = 3 + 4 + length + 4


### PR DESCRIPTION
## Summary
- add `GIB_MAGIC` constant
- use `GIB_MAGIC` in payload builder and parser

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e671f3688331b0a72fb9f2de856f