### PR TITLE
refactor: centralize history db name

### DIFF
--- a/gibberlink/__main__.py
+++ b/gibberlink/__main__.py
@@ -28,7 +28,7 @@ import time
 import wave
 from typing import List, Tuple, Iterable
 from .profiles import freq_profile
-from .constants import GIB_MAGIC
+from .constants import GIB_MAGIC, HISTORY_DB
 
 # ------------------------
 # Logging
@@ -321,7 +321,7 @@ def encode_bytes_to_wav(user_bytes: bytes, out_dir: str, base_name_hint: str,
     framed_hash = sha256_hex(payload)
     crc_hex = f"{binascii.crc32(user_bytes) & 0xFFFFFFFF:08x}"
 
-    db_path = os.path.join(out_dir, "gibberlink_history.db")
+    db_path = os.path.join(out_dir, HISTORY_DB)
     ensure_dir(out_dir)
 
     legacy_path = os.path.join(out_dir, "ghostlink_history.db")

--- a/gibberlink/constants.py
+++ b/gibberlink/constants.py
@@ -1,3 +1,6 @@
 """Shared constants for Gibberlink."""
 
 GIB_MAGIC = b"GIB"
+
+# SQLite database file storing encode history
+HISTORY_DB = "gibberlink_history.db"

--- a/tests/test_db_migration.py
+++ b/tests/test_db_migration.py
@@ -1,5 +1,6 @@
 from gibberlink import encode_bytes_to_wav
 from gibberlink.__main__ import db_init
+from gibberlink.constants import HISTORY_DB
 import sqlite3
 
 
@@ -21,7 +22,7 @@ def test_legacy_db_migrates(tmp_path):
         repeats=1,
         ramp_ms=5.0,
     )
-    new_db = tmp_path / "gibberlink_history.db"
+    new_db = tmp_path / HISTORY_DB
     assert new_db.exists()
     assert not legacy.exists()
     conn = sqlite3.connect(new_db)

--- a/tests/test_full_cycle.py
+++ b/tests/test_full_cycle.py
@@ -1,7 +1,6 @@
 from gibberlink import encode_bytes_to_wav
 from gibberlink.decoder import decode_wav
-
-HISTORY_DB_NAME = "gibberlink_history.db"
+from gibberlink.constants import HISTORY_DB
 
 
 def test_full_encode_decode_cycle(tmp_path):
@@ -23,7 +22,7 @@ def test_full_encode_decode_cycle(tmp_path):
         ramp_ms=5.0,
     )
     assert skipped is False
-    assert (out_dir / HISTORY_DB_NAME).exists()
+    assert (out_dir / HISTORY_DB).exists()
     decoded = decode_wav(
         path=path,
         baud=200.0,


### PR DESCRIPTION
## Summary
- add HISTORY_DB constant for encode history database
- use HISTORY_DB in encode logic and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896ee76c3c08331914aa624987aeb46