### PR TITLE
Strip RTF and non-ASCII from decoder output

### DIFF
--- a/tests/test_ascii_only.py
+++ b/tests/test_ascii_only.py
@@ -1,0 +1,11 @@
+from gibberlink.decoder import ascii_only
+
+
+def test_ascii_only_strips_rtf_control_words():
+    rtf = b"{\\rtf1\\ansi Bold \\b text\\b0 }"
+    assert ascii_only(rtf) == "Bold text"
+
+
+def test_ascii_only_drops_non_ascii():
+    data = "Hi \u2665".encode("utf-8")
+    assert ascii_only(data) == "Hi"


### PR DESCRIPTION
## Summary
- sanitize decoder CLI output to drop RTF control words and non-ASCII chars
- add helper and tests to ensure ASCII-only text

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896f6566138833193e300d1b012b3be