### PR TITLE
Generate slowed WAV variants after encoding

### DIFF
--- a/tests/test_cli_round_trip.py
+++ b/tests/test_cli_round_trip.py
@@ -12,8 +12,8 @@ def test_cli_round_trip(tmp_path):
         capture_output=True,
     )
     wav_files = list(Path(tmp_path).glob("*.wav"))
-    assert len(wav_files) == 1
-    wav_path = wav_files[0]
+    assert len(wav_files) == 4
+    wav_path = [p for p in wav_files if "slow" not in p.stem][0]
     # Decode using reference decoder CLI
     proc = subprocess.run(
         [sys.executable, "-m", "gibberlink.decoder", str(wav_path)],


### PR DESCRIPTION
## Summary
- Resample PCM data with new `stretch_audio` helper using linear interpolation
- Encode flow now reads written WAV and writes 0.75x, 0.5x, and 0.25x speed variants
- Adjust CLI round-trip test for multiple generated WAV files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68976e8e999083319de9e781fc1bfb9f