### PR TITLE
test: verify ghostlink entrypoint

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,20 @@
 import os
 import sys
+import subprocess
+from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def install_cli() -> None:
+    """Ensure the package is installed so CLI entry points are available."""
+    repo_root = Path(__file__).resolve().parents[1]
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "-e", str(repo_root)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )

--- a/tests/test_cli_round_trip.py
+++ b/tests/test_cli_round_trip.py
@@ -2,7 +2,7 @@ import subprocess
 from pathlib import Path
 
 
-def test_cli_round_trip(tmp_path):
+def test_cli_round_trip(tmp_path, install_cli):
     msg = "hello"
     # Encode message via CLI
     subprocess.run(


### PR DESCRIPTION
## Summary
- ensure tests install package so `ghostlink` console script is available
- run `ghostlink` via subprocess in round-trip CLI test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68978b15ada08331a7b3e41ed1538ec9