### PR TITLE
Add 10x slow variant output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ This is the agent team’s mission ID — unique for each message.
 
 After a mission, agents also leave behind slowed briefings and a MIDI transcript:
 
-- `_slow25.wav`, `_slow50.wav`, `_slow100.wav` stretch the run by 4/3×, 2× and 4× for easier analysis.
+- `_slow25.wav`, `_slow50.wav`, `_slow100.wav`, `_slow1000.wav` stretch the run by 4/3×, 2×, 4×, and ~10× for easier analysis.
 - A matching `.mid` file documents each carrier hop.
 - Use `--out-name` to choose the base filename; all companions inherit the same prefix.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ It defaults to **dense 8-FSK** with forward error correction, interleaving, and 
   Intersymbol gap (usually 0) and raised-cosine ramp per symbol to avoid clicks.
 - `--out-name <file.wav>`
   Override the auto-generated base name. Useful when embedding in a project;
-  slowed variants (`*_slow25.wav`, `*_slow50.wav`, `*_slow100.wav`) and the
+  slowed variants (`*_slow25.wav`, `*_slow50.wav`, `*_slow100.wav`, `*_slow1000.wav` ≈10×) and the
   companion MIDI file use the same prefix.
 
 ---
@@ -108,6 +108,7 @@ Each encode produces:
 - `out/<base>_<sha12>_slow25.wav` — 25% slower (duration ×4/3)
 - `out/<base>_<sha12>_slow50.wav` — 50% slower (duration ×2)
 - `out/<base>_<sha12>_slow100.wav` — 100% slower (duration ×4)
+- `out/<base>_<sha12>_slow1000.wav` — one-tenth speed (duration ×10)
 - `out/<base>_<sha12>.mid` — MIDI rendering of the carrier sequence
 - `out/ghostlink_history.db` — SQLite history of encodes
 

--- a/ghostlink/__main__.py
+++ b/ghostlink/__main__.py
@@ -462,7 +462,7 @@ def encode_bytes_to_wav(user_bytes: bytes, out_dir: str, base_name_hint: str,
         logging.warning(f"[!] Unexpected channel count: {channels}")
 
     # Generate slowed variants
-    for factor, suffix in {0.75: "slow25", 0.5: "slow50", 0.25: "slow100"}.items():
+    for factor, suffix in {0.75: "slow25", 0.5: "slow50", 0.25: "slow100", 0.1: "slow1000"}.items():
         try:
             stretched = stretch_audio(pcm_data, factor)
             slow_path = os.path.splitext(out_path)[0] + f"_{suffix}.wav"

--- a/tests/test_cli_round_trip.py
+++ b/tests/test_cli_round_trip.py
@@ -1,6 +1,13 @@
 import subprocess
+import wave
 from pathlib import Path
 
+import pytest
+
+
+def _duration(p: Path) -> float:
+    with wave.open(str(p), "rb") as wf:
+        return wf.getnframes() / wf.getframerate()
 
 def test_cli_round_trip(tmp_path, install_cli):
     msg = "hello"
@@ -11,14 +18,17 @@ def test_cli_round_trip(tmp_path, install_cli):
         capture_output=True,
     )
     wav_files = list(Path(tmp_path).glob("*.wav"))
-    assert len(wav_files) == 4
+    assert len(wav_files) == 5
     slow = {p.name for p in wav_files if "slow" in p.stem}
     assert any(name.endswith("_slow25.wav") for name in slow)
     assert any(name.endswith("_slow50.wav") for name in slow)
     assert any(name.endswith("_slow100.wav") for name in slow)
+    assert any(name.endswith("_slow1000.wav") for name in slow)
+    wav_path = [p for p in wav_files if "slow" not in p.stem][0]
+    slow1000 = [p for p in wav_files if p.name.endswith("_slow1000.wav")][0]
+    assert _duration(slow1000) == pytest.approx(_duration(wav_path) * 10, rel=0.01)
     midi_files = list(Path(tmp_path).glob("*.mid"))
     assert len(midi_files) == 1
-    wav_path = [p for p in wav_files if "slow" not in p.stem][0]
     # Decode using reference decoder CLI
     proc = subprocess.run(
         ["ghostlink-decode", str(wav_path)],

--- a/tests/test_out_name.py
+++ b/tests/test_out_name.py
@@ -1,8 +1,16 @@
 import subprocess
+import wave
 from pathlib import Path
+
+import pytest
 
 from ghostlink import encode_bytes_to_wav
 from ghostlink.constants import HISTORY_DB
+
+
+def _duration(p: Path) -> float:
+    with wave.open(str(p), "rb") as wf:
+        return wf.getnframes() / wf.getframerate()
 
 
 def test_encode_bytes_to_wav_out_name(tmp_path):
@@ -27,6 +35,10 @@ def test_encode_bytes_to_wav_out_name(tmp_path):
     assert (tmp_path / "custom_slow25.wav").exists()
     assert (tmp_path / "custom_slow50.wav").exists()
     assert (tmp_path / "custom_slow100.wav").exists()
+    assert (tmp_path / "custom_slow1000.wav").exists()
+    main_dur = _duration(tmp_path / "custom.wav")
+    slow_dur = _duration(tmp_path / "custom_slow1000.wav")
+    assert slow_dur == pytest.approx(main_dur * 10, rel=0.01)
     assert (tmp_path / "custom.mid").exists()
     assert (tmp_path / HISTORY_DB).exists()
 
@@ -51,6 +63,10 @@ def test_cli_out_name(tmp_path):
     assert "cli_slow25.wav" in slow
     assert "cli_slow50.wav" in slow
     assert "cli_slow100.wav" in slow
+    assert "cli_slow1000.wav" in slow
+    main_dur = _duration(tmp_path / "cli.wav")
+    slow_dur = _duration(tmp_path / "cli_slow1000.wav")
+    assert slow_dur == pytest.approx(main_dur * 10, rel=0.01)
     assert (tmp_path / "cli.mid").exists()
 
 

--- a/tests/test_slow_durations.py
+++ b/tests/test_slow_durations.py
@@ -28,7 +28,7 @@ def test_slowscaled_durations(tmp_path):
         ramp_ms=5.0,
     )
     main_dur = _duration(Path(path))
-    factors = {"slow25": 4 / 3, "slow50": 2.0, "slow100": 4.0}
+    factors = {"slow25": 4 / 3, "slow50": 2.0, "slow100": 4.0, "slow1000": 10.0}
     for suffix, factor in factors.items():
         slow = Path(path).with_name(Path(path).stem + f"_{suffix}.wav")
         assert slow.exists()


### PR DESCRIPTION
## Summary
- add new `_slow1000.wav` output for ~10× duration
- update tests and docs for additional slowed variant

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689793a9eedc8331a59667d379666911