### PR TITLE
Centralize history DB at project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It defaults to **dense 8-FSK** with forward error correction, interleaving, and 
 - **Codec-safe by design:** carriers live in 1.5–5 kHz (“streaming” profile, default) or 1.8–6 kHz (“studio”).
 - **Dense by default:** 8-FSK + Hamming(7,4) + interleaving + optional repeats.
 - **Hash-based dedupe:** payload frame SHA-256 is the unique key; if a prior identical encode exists on disk, the run is skipped.
-- **SQLite history:** every encode (or skip) is tracked in `ghostlink_history.db` in the output directory (legacy `gibberlink_history.db` files are migrated automatically).
+- **SQLite history:** every encode (or skip) is tracked in a project-root `ghostlink_history.db`, providing a global log across all runs.
 - **Lightweight dependency:** uses `mido` to emit companion MIDI files.
 - **Three input modes:** CLI text, single file, or directory of text files.
 
@@ -110,7 +110,7 @@ Each encode produces:
 - `out/<base>_<sha12>_slow100.wav` — 100% slower (duration ×4)
 - `out/<base>_<sha12>_slow1000.wav` — one-tenth speed (duration ×10)
 - `out/<base>_<sha12>.mid` — MIDI rendering of the carrier sequence
-- `out/ghostlink_history.db` — SQLite history of encodes
+- `ghostlink_history.db` — SQLite history of all encodes, stored in the project root
 
 Filenames include the first 12 hex chars of the framed payload hash (sha256) for traceability.
 

--- a/ghostlink/__main__.py
+++ b/ghostlink/__main__.py
@@ -354,18 +354,8 @@ def encode_bytes_to_wav(user_bytes: bytes, out_dir: str, base_name_hint: str,
     framed_hash = sha256_hex(payload)
     crc_hex = f"{binascii.crc32(user_bytes) & 0xFFFFFFFF:08x}"
 
-    db_path = os.path.join(out_dir, HISTORY_DB)
     ensure_dir(out_dir)
-
-    legacy_path = os.path.join(out_dir, "gibberlink_history.db")
-    if not os.path.exists(db_path) and os.path.exists(legacy_path):
-        try:
-            os.rename(legacy_path, db_path)
-            logging.info(f"[i] Migrated legacy DB: {legacy_path} -> {db_path}")
-        except Exception as e:
-            logging.warning(f"[!] Failed to migrate legacy DB: {e}")
-            db_path = legacy_path
-
+    db_path = os.path.abspath(HISTORY_DB)
     db_init(db_path)
 
     exists, prior_path = db_has_hash(db_path, framed_hash)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from ghostlink.constants import HISTORY_DB
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -18,3 +19,10 @@ def install_cli() -> None:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
+
+
+@pytest.fixture(autouse=True)
+def clean_history_db() -> None:
+    db_path = Path.cwd() / HISTORY_DB
+    if db_path.exists():
+        db_path.unlink()

--- a/tests/test_db_migration.py
+++ b/tests/test_db_migration.py
@@ -1,13 +1,10 @@
 from ghostlink import encode_bytes_to_wav
-from ghostlink.__main__ import db_init
 from ghostlink.constants import HISTORY_DB
 import sqlite3
 from pathlib import Path
 
 
-def test_legacy_db_migrates(tmp_path):
-    legacy = tmp_path / "gibberlink_history.db"
-    db_init(str(legacy))
+def test_db_in_project_root(tmp_path):
     path, _ = encode_bytes_to_wav(
         user_bytes=b"hi",
         out_dir=str(tmp_path),
@@ -24,10 +21,10 @@ def test_legacy_db_migrates(tmp_path):
         ramp_ms=5.0,
     )
     assert Path(path).with_suffix(".mid").exists()
-    new_db = tmp_path / HISTORY_DB
-    assert new_db.exists()
-    assert not legacy.exists()
-    conn = sqlite3.connect(new_db)
+    root_db = Path.cwd() / HISTORY_DB
+    assert root_db.exists()
+    assert not (tmp_path / HISTORY_DB).exists()
+    conn = sqlite3.connect(root_db)
     try:
         count = conn.execute("SELECT COUNT(*) FROM encodes").fetchone()[0]
     finally:

--- a/tests/test_full_cycle.py
+++ b/tests/test_full_cycle.py
@@ -37,7 +37,7 @@ def test_full_encode_decode_cycle(tmp_path):
         ramp_ms=5.0,
     )
     assert skipped is False
-    assert (out_dir / HISTORY_DB).exists()
+    assert (Path.cwd() / HISTORY_DB).exists()
     midi_path = Path(path).with_suffix(".mid")
     assert midi_path.exists()
     for suffix in ("slow25", "slow50", "slow100", "slow1000"):

--- a/tests/test_out_name.py
+++ b/tests/test_out_name.py
@@ -40,7 +40,7 @@ def test_encode_bytes_to_wav_out_name(tmp_path):
     slow_dur = _duration(tmp_path / "custom_slow1000.wav")
     assert slow_dur == pytest.approx(main_dur * 10, rel=0.01)
     assert (tmp_path / "custom.mid").exists()
-    assert (tmp_path / HISTORY_DB).exists()
+    assert (Path.cwd() / HISTORY_DB).exists()
 
 
 def test_cli_out_name(tmp_path):
@@ -68,6 +68,7 @@ def test_cli_out_name(tmp_path):
     slow_dur = _duration(tmp_path / "cli_slow1000.wav")
     assert slow_dur == pytest.approx(main_dur * 10, rel=0.01)
     assert (tmp_path / "cli.mid").exists()
+    assert (Path.cwd() / HISTORY_DB).exists()
 
 
 def test_cli_out_name_rejected_for_dir(tmp_path):


### PR DESCRIPTION
## Summary
- Store ghostlink_history.db in the project root, removing legacy per-directory migration logic
- Update tests to expect a single global DB and ensure it is cleaned between runs
- Document that history is tracked globally via the root-level ghostlink_history.db

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689794ff4f78833190086c426c38839f