### PR TITLE
Add FastAPI web interface

### DIFF
--- a/ghostlink/webapp/__init__.py
+++ b/ghostlink/webapp/__init__.py
@@ -1,0 +1,3 @@
+from .app import app, main
+
+__all__ = ["app", "main"]

--- a/ghostlink/webapp/static/style.css
+++ b/ghostlink/webapp/static/style.css
@@ -1,0 +1,2 @@
+body { font-family: sans-serif; margin: 2em; }
+textarea { width: 100%; height: 4em; }

--- a/ghostlink/webapp/templates/index.html
+++ b/ghostlink/webapp/templates/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>GhostLink Web</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <h1>GhostLink Web Interface</h1>
+    <section>
+        <h2>Encode</h2>
+        <form action="/encode" method="post" enctype="multipart/form-data">
+            <textarea name="text" placeholder="Text to encode"></textarea><br>
+            <input type="file" name="file"><br>
+            <button type="submit">Encode</button>
+        </form>
+    </section>
+    <section>
+        <h2>Decode</h2>
+        <form action="/decode" method="post" enctype="multipart/form-data">
+            <input type="file" name="wav"><br>
+            <button type="submit">Decode</button>
+        </form>
+    </section>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,9 @@ readme = "README.md"
 authors = [{name = "GhostLink Contributors"}]
 license = {text = "MIT"}
 requires-python = ">=3.8"
-dependencies = ["mido"]
+dependencies = ["fastapi", "jinja2", "mido", "python-multipart", "uvicorn"]
 
 [project.scripts]
 ghostlink = "ghostlink.__main__:main"
 ghostlink-decode = "ghostlink.decoder:main"
+ghostlink-web = "ghostlink.webapp.app:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 # Lightweight MIDI library for .mid output
 mido
+fastapi
+uvicorn
+jinja2
+python-multipart
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+
+from ghostlink.webapp.app import app
+
+
+client = TestClient(app)
+
+
+def test_encode_decode_cycle():
+    resp = client.post("/encode", data={"text": "secret"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("audio/wav")
+
+    wav_bytes = resp.content
+    files = {"wav": ("msg.wav", wav_bytes, "audio/wav")}
+    resp2 = client.post("/decode", files=files)
+    assert resp2.status_code == 200
+    assert resp2.text.strip() == "secret"
+
+
+def test_get_index_page():
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "GhostLink Web Interface" in resp.text


### PR DESCRIPTION
## Summary
- add FastAPI web application exposing encode and decode endpoints with an HTML form
- provide CLI entrypoint `ghostlink-web` to serve the FastAPI app
- cover encoding and decoding workflow with FastAPI TestClient tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68983a05d880833183d1bd1ebd5032fb