### PR TITLE
Pin dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,14 @@ readme = "README.md"
 authors = [{name = "GhostLink Contributors"}]
 license = {text = "MIT"}
 requires-python = ">=3.8"
-dependencies = ["fastapi", "jinja2", "mido", "python-multipart", "uvicorn"]
+dependencies = [
+    "fastapi==0.116.1",
+    "jinja2==3.1.6",
+    "mido==1.3.3",
+    "python-multipart==0.0.20",
+    "uvicorn==0.35.0",
+    "httpx==0.28.1",
+]
 
 [project.scripts]
 ghostlink = "ghostlink.__main__:main"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==8.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Lightweight MIDI library for .mid output
-mido
-fastapi
-uvicorn
-jinja2
-python-multipart
-httpx
+mido==1.3.3
+fastapi==0.116.1
+uvicorn==0.35.0
+jinja2==3.1.6
+python-multipart==0.0.20
+httpx==0.28.1
 


### PR DESCRIPTION
## Summary
- pin project dependencies in `requirements.txt` and `pyproject.toml`
- add `requirements-dev.txt` for running tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898af91ce7c833187f1be65e5017863