### PR TITLE
Handle invalid WAV uploads in decode endpoint

### DIFF
--- a/ghostlink/webapp/app.py
+++ b/ghostlink/webapp/app.py
@@ -93,15 +93,21 @@ async def decode(wav: UploadFile = File(...)) -> PlainTextResponse:
                 if total > MAX_UPLOAD_BYTES:
                     raise HTTPException(status_code=413, detail="File too large")
                 fh.write(chunk)
-        payload = decode_wav(
-            path=str(wav_path),
-            baud=90.0,
-            dense=True,
-            mix_profile="streaming",
-            preamble_s=0.8,
-            interleave_depth=4,
-            repeats=2,
-        )
+        try:
+            payload = decode_wav(
+                path=str(wav_path),
+                baud=90.0,
+                dense=True,
+                mix_profile="streaming",
+                preamble_s=0.8,
+                interleave_depth=4,
+                repeats=2,
+            )
+        except Exception:
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid or unsupported WAV file",
+            )
     try:
         text = payload.decode("utf-8")
     except Exception:

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -56,3 +56,18 @@ def test_decode_rejects_large_file():
     resp = client.post("/decode", files=files)
     assert resp.status_code == 413
 
+
+def test_decode_rejects_non_wav_data():
+    files = {"wav": ("bad.txt", b"not a wav", "text/plain")}
+    resp = client.post("/decode", files=files)
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid or unsupported WAV file"
+
+
+def test_decode_rejects_malformed_wav():
+    malformed = b"RIFF\x24\x00\x00\x00WAVE"
+    files = {"wav": ("bad.wav", malformed, "audio/wav")}
+    resp = client.post("/decode", files=files)
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid or unsupported WAV file"
+


### PR DESCRIPTION
## Summary
- Raise HTTP 400 for invalid or unsupported WAV files in the web decoder
- Test non-WAV and malformed WAV uploads return 400

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b383323c83319940c92bd2681ea8