### PR TITLE
Enforce exclusive inputs for encode endpoint

### DIFF
--- a/ghostlink/webapp/app.py
+++ b/ghostlink/webapp/app.py
@@ -35,7 +35,9 @@ async def index(request: Request) -> HTMLResponse:
 
 @app.post("/encode")
 async def encode(text: Optional[str] = Form(None), file: UploadFile | None = File(None)) -> Response:
-    if text is None and file is None:
+    if (text not in (None, "")) and file is not None:
+        raise HTTPException(status_code=400, detail="Provide either text or file, not both")
+    if (text in (None, "")) and file is None:
         raise HTTPException(status_code=400, detail="Provide text or file")
 
     if file is not None:

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -16,6 +16,13 @@ def test_encode_returns_wav():
     assert resp.content[:4] == b"RIFF"
 
 
+def test_encode_rejects_both_fields():
+    files = {"file": ("msg.txt", b"data", "text/plain")}
+    resp = client.post("/encode", data={"text": "secret"}, files=files)
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Provide either text or file, not both"
+
+
 def test_decode_known_wav():
     message = b"decode me"
     with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- validate that /encode receives either text or file, but not both
- add regression test covering 400 response when both fields supplied

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b5075710833191d3c217fc0aff7f