### PR TITLE
Add CLI to webapp and tighten installer checks

### DIFF
--- a/ghostlink/webapp/app.py
+++ b/ghostlink/webapp/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -118,6 +119,28 @@ async def decode(wav: UploadFile = File(...)) -> PlainTextResponse:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="GhostLink web application")
+    parser.add_argument("--host", default="0.0.0.0", help="Host address to bind")
+    parser.add_argument("--port", type=int, default=8000, help="Port to listen on")
+    parser.add_argument(
+        "--version", action="store_true", help="Print version and exit"
+    )
+    args = parser.parse_args()
+
+    if args.version:
+        import importlib.metadata
+
+        try:
+            version = importlib.metadata.version("ghostlink")
+        except importlib.metadata.PackageNotFoundError:  # pragma: no cover - fallback
+            version = "unknown"
+        print(version)
+        return
+
     import uvicorn
 
-    uvicorn.run("ghostlink.webapp.app:app", host="0.0.0.0", port=8000)
+    uvicorn.run("ghostlink.webapp.app:app", host=args.host, port=args.port)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -48,7 +48,13 @@ def verify_executables(bindir: Path) -> None:
         exe_path = bindir / (exe + (".exe" if os.name == "nt" else ""))
         print(f"Verifying {exe}...")
         try:
-            subprocess.check_call([str(exe_path), "--help"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run(
+                [str(exe_path), "--help"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+                check=True,
+            )
         except Exception as exc:  # pragma: no cover - diagnostic output
             print(f"[x] Failed to run {exe}: {exc}", file=sys.stderr)
             raise SystemExit(1)


### PR DESCRIPTION
## Summary
- add argparse-based CLI to `ghostlink-web` supporting host/port selection and a version flag
- guard installer executable verification with `subprocess.run(..., timeout=5)`

## Testing
- `python -m ghostlink.webapp.app --help`
- `python -m ghostlink.webapp.app --version`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898c52def508331994503f13093239e