### PR TITLE
Enforce text upload limit in webapp

### DIFF
--- a/ghostlink/webapp/app.py
+++ b/ghostlink/webapp/app.py
@@ -55,7 +55,10 @@ async def encode(text: Optional[str] = Form(None), file: UploadFile | None = Fil
         data = b"".join(chunks)
         name_hint = file.filename or "upload"
     else:
-        data = text.encode("utf-8")
+        encoded = text.encode("utf-8")
+        if len(encoded) > MAX_UPLOAD_BYTES:
+            raise HTTPException(status_code=413, detail="Text too large")
+        data = encoded
         name_hint = "message"
 
     with TemporaryDirectory() as tmpdir:

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -63,6 +63,13 @@ def test_encode_rejects_large_file():
     assert resp.status_code == 413
 
 
+def test_encode_rejects_large_text():
+    text = "x" * (MAX_UPLOAD_BYTES + 1)
+    resp = client.post("/encode", data={"text": text})
+    assert resp.status_code == 413
+    assert resp.json()["detail"] == "Text too large"
+
+
 def test_decode_rejects_large_file():
     data = b"x" * (MAX_UPLOAD_BYTES + 1)
     files = {"wav": ("big.wav", data, "audio/wav")}


### PR DESCRIPTION
## Summary
- Reject text submissions larger than the MAX_UPLOAD_BYTES limit in `/encode`
- Add regression test ensuring oversized text requests return HTTP 413

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c745fa5883319f8f2c5a3dd27eec