### PR TITLE
Add timeout handling for install script executable checks

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -44,6 +44,7 @@ def install_project(pip: Path, root: Path) -> None:
 
 def verify_executables(bindir: Path) -> None:
     executables = ["ghostlink", "ghostlink-decode", "ghostlink-web"]
+    timeout = 5
     for exe in executables:
         exe_path = bindir / (exe + (".exe" if os.name == "nt" else ""))
         print(f"Verifying {exe}...")
@@ -52,9 +53,12 @@ def verify_executables(bindir: Path) -> None:
                 [str(exe_path), "--help"],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
-                timeout=5,
+                timeout=timeout,
                 check=True,
             )
+        except subprocess.TimeoutExpired:
+            print(f"[x] {exe} timed out after {timeout}s", file=sys.stderr)
+            raise SystemExit(1)
         except Exception as exc:  # pragma: no cover - diagnostic output
             print(f"[x] Failed to run {exe}: {exc}", file=sys.stderr)
             raise SystemExit(1)


### PR DESCRIPTION
## Summary
- ensure GhostLink executables are verified with a 5s timeout
- report a clear error if an executable verification times out

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898c88972ac83319a6d03029b59133b